### PR TITLE
fix: make `AppProcess.launch` a symbol method

### DIFF
--- a/src/app-process.ts
+++ b/src/app-process.ts
@@ -9,6 +9,7 @@ export interface AppProcessOptions {
 }
 
 export const kUrl = Symbol('kUrl')
+export const kLaunch = Symbol('kLaunch')
 
 export class AppProcess {
   private io?: ChildProcess
@@ -30,7 +31,11 @@ export class AppProcess {
     return url
   }
 
-  public async launch(): Promise<ChildProcess> {
+  /**
+   * Spawns the child process with the configured application.
+   * @note This method must never be used publicly. Use `launcher.run()` instead.
+   */
+  async [kLaunch](): Promise<ChildProcess> {
     const [command, ...args] = this.options.command.split(' ')
 
     invariant(
@@ -56,6 +61,9 @@ export class AppProcess {
     return this.io
   }
 
+  /**
+   * Stop the running application.
+   */
   public async dispose(): Promise<void> {
     invariant(
       !this.controller.signal.aborted,

--- a/src/define-launcher.ts
+++ b/src/define-launcher.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'node:child_process'
-import { AppProcess, kUrl } from './app-process.js'
+import { AppProcess, kLaunch, kUrl } from './app-process.js'
 import { waitForPort } from './wait-for-port.js'
 
 export interface LauncherInit<Context, Env extends Record<string, string>> {
@@ -113,7 +113,7 @@ export function defineLauncher<
         env,
         cwd: runOptions?.cwd,
       })
-      const childProcess = await app.launch()
+      const childProcess = await app[kLaunch]()
 
       if (options?.debug) {
         childProcess.stdout?.pipe(process.stdout)


### PR DESCRIPTION
Having an `AppProcess` instance that has a `launch` method after the user has already called `launcher.run()` is confusing:

```ts
const app = await launcher.run()
app.launch() // ?? Should I call this? Should I not?
```

- Locks that method behind a symbol so it can still be used from `defineLauncher` but never by the user. 